### PR TITLE
Bump MODULE_VERSION to 0.1.1

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -53,4 +53,4 @@ module_exit(vendor_reset_exit);
 MODULE_LICENSE("GPL v2");
 MODULE_AUTHOR("Geoffrey McRae <geoff@hostfission.com>");
 MODULE_AUTHOR("Adam Madsen <adam@ajmadsen.com>");
-MODULE_VERSION("0.1.0");
+MODULE_VERSION("0.1.1");


### PR DESCRIPTION
MODULE_VERSION was still set to the old version of 0.1.0, which would give out a warning when DKIM performed version sanity checks.